### PR TITLE
Accept Environment vars in MCP config

### DIFF
--- a/src/lib/ai/mcp/create-mcp-client.ts
+++ b/src/lib/ai/mcp/create-mcp-client.ts
@@ -82,7 +82,16 @@ export class MCPClient {
         transport = new StdioClientTransport({
           command: config.command,
           args: config.args,
-          env: config.env,
+          // Merge process.env with config.env, ensuring PATH is preserved and filtering out undefined values
+          env: Object.entries({ ...process.env, ...config.env }).reduce(
+            (acc, [key, value]) => {
+              if (value !== undefined) {
+                acc[key] = value;
+              }
+              return acc;
+            },
+            {} as Record<string, string>,
+          ),
           cwd: process.cwd(),
         });
       } else if (isMaybeSseConfig(this.serverConfig)) {


### PR DESCRIPTION
I wanted to connect the mcp-client-chatbot to mcp.garden so I could dynamically turn tools on/off. mcp.garden currently requires passing an api key using "env" in the config.

This PR includes an update to the StdioClientTransport function which allows for env vars to now be accepted!

Great job team, I'm hoping to get this project integrated directly into mcp.garden soon!

![Screenshot 2025-04-21 at 2 31 53 PM](https://github.com/user-attachments/assets/4f5a8bd7-8e97-49c5-a9af-82a044336605)
![Screenshot 2025-04-21 at 2 48 15 PM](https://github.com/user-attachments/assets/72a3a58c-51b6-4c11-a1a8-d46bbba5ed70)
![Screenshot 2025-04-21 at 2 31 38 PM](https://github.com/user-attachments/assets/b196e154-c0c4-4eea-93a3-d97f294d6540)