### PR TITLE
Add enter key functionality to create project popup

### DIFF
--- a/src/components/create-project-popup.tsx
+++ b/src/components/create-project-popup.tsx
@@ -38,6 +38,12 @@ export function CreateProjectPopup({ children }: PropsWithChildren) {
       .ifFail(handleErrorWithToast);
   };
 
+  const handleEnterKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleCreate();
+    }
+  };
+
   useEffect(() => {
     if (!isOpen) {
       setName("");
@@ -75,6 +81,7 @@ export function CreateProjectPopup({ children }: PropsWithChildren) {
             id="name"
             value={name}
             onChange={(e) => setName(e.target.value)}
+            onKeyDown={handleEnterKey}
             placeholder="eg. Korea Trip Plan"
             className="w-full bg-card"
           />

--- a/src/components/create-project-popup.tsx
+++ b/src/components/create-project-popup.tsx
@@ -2,7 +2,7 @@
 import { insertProjectAction } from "@/app/api/chat/actions";
 import { Lightbulb, Loader } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { PropsWithChildren, useEffect, useState } from "react";
+import React, { KeyboardEvent, PropsWithChildren, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { mutate } from "swr";
 import { safe } from "ts-safe";
@@ -38,7 +38,7 @@ export function CreateProjectPopup({ children }: PropsWithChildren) {
       .ifFail(handleErrorWithToast);
   };
 
-  const handleEnterKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleEnterKey = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       handleCreate();
     }


### PR DESCRIPTION
## Changes
- Added enter key functionality to project creation popup
  - Users can now create a project by pressing enter after entering the project name
  - Improved user experience by providing an alternative input method alongside the existing 'Create' button

## Testing
1. Open the project creation popup and enter a project name
2. Press enter to verify that the project is created
3. Verify that project creation still works through the 'Create' button

## Related Issues
- Improving user convenience during project creation