### PR TITLE
Fix prevent duplicate project creation on Korean input - ignore Enter

### DIFF
--- a/src/components/create-project-popup.tsx
+++ b/src/components/create-project-popup.tsx
@@ -39,7 +39,7 @@ export function CreateProjectPopup({ children }: PropsWithChildren) {
   };
 
   const handleEnterKey = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.nativeEvent.isComposing) {
       handleCreate();
     }
   };


### PR DESCRIPTION
## Description
This PR fixes an issue where projects were being created twice when using Korean input. The problem occurred because the Enter key event was being triggered twice during IME (Input Method Editor) composition.

### Changes
- Added a check for `e.nativeEvent.isComposing` in the Enter key handler
- This prevents duplicate project creation when using Korean input

### Technical Details
- The issue was caused by the IME composition process triggering the Enter key event twice:
  1. Once when the composition is completed
  2. Once for the actual Enter key press
- The fix ignores the Enter event during IME composition by checking `e.nativeEvent.isComposing`

### Testing
- Tested with Korean input using various IMEs
- Verified that projects are now created only once when pressing Enter
- Confirmed that English input continues to work as expected

### Related Issues
- Fixes the issue of duplicate project creation with Korean input