### PR TITLE
fix: DB defaults to SQLite even when USE_FILE_SYSTEM_DB is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ OPENAI_API_KEY=****
 # ANTHROPIC_API_KEY=****
 ```
 
-SQLite is the default DB (`db.sqlite`). To use PostgreSQL, set `USE_FILE_SYSTEM_DB=false` and define `DATABASE_URL` in `.env`.
+SQLite is the default DB (`db.sqlite`). To use PostgreSQL, set `USE_FILE_SYSTEM_DB=false` and define `POSTGRES_URL` in `.env`.
 
 -----
 

--- a/docs/ko.md
+++ b/docs/ko.md
@@ -138,7 +138,7 @@ OPENAI_API_KEY=****
 # ANTHROPIC_API_KEY=****
 ```
 
-SQLite가 기본 DB(`db.sqlite`)입니다. PostgreSQL을 사용하려면 `.env`에서 `USE_FILE_SYSTEM_DB=false`로 설정하고 `DATABASE_URL`을 정의하세요.
+SQLite가 기본 DB(`db.sqlite`)입니다. PostgreSQL을 사용하려면 `.env`에서 `USE_FILE_SYSTEM_DB=false`로 설정하고 `POSTGRES_URL`을 정의하세요.
 
 -----
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -5,15 +5,15 @@ config();
 
 const dialect = process.env.USE_FILE_SYSTEM_DB ? "sqlite" : "postgresql";
 
-const url = process.env.USE_FILE_SYSTEM_DB
+const url = process.env.USE_FILE_SYSTEM_DB === "true"
   ? process.env.FILEBASE_URL!
   : process.env.POSTGRES_URL!;
 
-const schema = process.env.USE_FILE_SYSTEM_DB
+const schema = process.env.USE_FILE_SYSTEM_DB === "true"
   ? "./src/lib/db/sqlite/schema.sqlite.ts"
   : "./src/lib/db/pg/schema.pg.ts";
 
-const out = process.env.USE_FILE_SYSTEM_DB
+const out = process.env.USE_FILE_SYSTEM_DB === "true"
   ? "./src/lib/db/migrations/sqlite"
   : "./src/lib/db/migrations/pg";
 

--- a/scripts/db-migrate.ts
+++ b/scripts/db-migrate.ts
@@ -5,7 +5,7 @@ import { colorize } from "consola/utils";
 config();
 
 let promise: Promise<any>;
-if (process.env.USE_FILE_SYSTEM_DB) {
+if (process.env.USE_FILE_SYSTEM_DB === "true") {
   promise = import("lib/db/sqlite/migrate.sqlite");
 } else {
   promise = import("lib/db/pg/migrate.pg");

--- a/src/lib/db/service.ts
+++ b/src/lib/db/service.ts
@@ -5,14 +5,14 @@ import { sqliteChatService } from "./sqlite/services/chat-service.sqlite";
 import { sqliteUserService } from "./sqlite/services/user-service.sqlite";
 import { sqliteMcpService } from "./sqlite/services/mcp-service.sqlite";
 
-export const chatService = process.env.USE_FILE_SYSTEM_DB
+export const chatService = process.env.USE_FILE_SYSTEM_DB === "true"
   ? sqliteChatService
   : pgChatService;
 
-export const userService = process.env.USE_FILE_SYSTEM_DB
+export const userService = process.env.USE_FILE_SYSTEM_DB === "true"
   ? sqliteUserService
   : pgUserService;
 
-export const mcpService = process.env.USE_FILE_SYSTEM_DB
+export const mcpService = process.env.USE_FILE_SYSTEM_DB === "true"
   ? sqliteMcpService
   : pgMcpService;


### PR DESCRIPTION
1. The environment variable `process.env.USE_FILE_SYSTEM_DB` returns a string, which causes the application to always select the SQLite database.
2. Updated README.md to replace `DATABASE_URL` with `POSTGRES_URL`.