### PR TITLE
feat: add remark-gfm for table / footnote support

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^2.1.9",
     "recharts": "^2.15.3",
+    "remark-gfm": "^4.0.1",
     "server-only": "^0.0.1",
     "shiki": "^3.4.2",
     "sonner": "^2.0.3",

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import React, { memo, PropsWithChildren } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { PreBlock } from "./pre-block";
 import { isJson, isString, toAny } from "lib/utils";
 import JsonView from "ui/json-view";
@@ -148,7 +149,12 @@ const NonMemoizedMarkdown = ({ children }: { children: string }) => {
       {isJson(children) ? (
         <JsonView data={children} />
       ) : (
-        <ReactMarkdown components={components}>{children}</ReactMarkdown>
+        <ReactMarkdown
+          components={components}
+          remarkPlugins={[remarkGfm]}
+        >
+          {children}
+        </ReactMarkdown>
       )}
     </article>
   );


### PR DESCRIPTION
Right now, the agent cant output rendered tables and footnotes.