### PR TITLE
Add open router

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The `pnpm i` command generates a `.env` file. Add your API keys there:
 GOOGLE_GENERATIVE_AI_API_KEY=****
 OPENAI_API_KEY=****
 ANTHROPIC_API_KEY=****
+OPENROUTER_API_KEY=****
 AUTH_SECRET=
 POSTGRES_URL=
 ```

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@ai-sdk/react": "^1.2.12",
     "@ai-sdk/xai": "^1.2.16",
     "@modelcontextprotocol/sdk": "^1.11.3",
+    "@openrouter/ai-sdk-provider": "^0.4.6",
     "@radix-ui/react-accordion": "^1.2.10",
     "@radix-ui/react-avatar": "^1.1.9",
     "@radix-ui/react-checkbox": "^1.3.1",

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -5,6 +5,7 @@ import { anthropic } from "@ai-sdk/anthropic";
 import { xai } from "@ai-sdk/xai";
 import { LanguageModel, wrapLanguageModel } from "ai";
 import { gemmaToolMiddleware } from "@ai-sdk-tool/parser";
+import { openrouter } from '@openrouter/ai-sdk-provider';
 
 export const allModels = {
   openai: {
@@ -42,6 +43,10 @@ export const allModels = {
       middleware: gemmaToolMiddleware,
     }),
   },
+  openRouter: {
+    "qwen3-8b:free": openrouter("qwen/qwen3-8b:free"),
+    "qwen3-14b:free": openrouter("qwen/qwen3-14b:free")
+  }
 } as const;
 
 export const isToolCallUnsupportedModel = (model: LanguageModel) => {
@@ -52,6 +57,8 @@ export const isToolCallUnsupportedModel = (model: LanguageModel) => {
     allModels.xai["grok-3-mini"],
     allModels.google["gemini-2.0-thinking"],
     allModels.ollama["gemma3:1b"],
+    allModels.openRouter["qwen3-8b:free"],
+    allModels.openRouter["qwen3-14b:free"],
   ].includes(model);
 };
 


### PR DESCRIPTION
I saw another [PR](https://github.com/cgoinglove/mcp-client-chatbot/pull/15) for Open Router integration. But it seems to focus more on custom providers and has many changes.

This PR, on the other hand, only adds a few lines of code that use the `@openrouter/ai-sdk-provider` library. It simply shows just how to use `Open Router`.