### PR TITLE
feat: add file attach support

### DIFF
--- a/src/components/file-mode-picker.tsx
+++ b/src/components/file-mode-picker.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "ui/popover";
+import { Button } from "ui/button";
+import { Paperclip } from "lucide-react";
+
+interface FileModePickerProps {
+  file: File;
+  onSelect: (mode: "text" | "binary") => void;
+  onClose: () => void;
+}
+
+function truncateFileName(name: string): string {
+  const maxStart = 10;
+  const dotIndex = name.lastIndexOf(".");
+  if (dotIndex === -1 || dotIndex <= maxStart) {
+    if (name.length <= maxStart) return name;
+    return name.slice(0, maxStart) + "...";
+  }
+  const start = name.slice(0, maxStart);
+  const ext = name.slice(dotIndex);
+  return `${start}...${ext}`;
+}
+
+export function FileModePicker({
+  file,
+  onSelect,
+  onClose,
+}: FileModePickerProps) {
+  const [open, setOpen] = useState(true);
+
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (!isOpen) onClose();
+  };
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <div className="cursor-pointer text-muted-foreground border rounded-full p-2 bg-transparent hover:bg-muted transition-all duration-200">
+          <Paperclip className="size-4" />
+        </div>
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="center"
+        className="p-4 w-56 rounded-lg shadow-md"
+      >
+        <div className="mb-3 font-semibold text-center" title={file.name}>
+          How to upload &quot;{truncateFileName(file.name)}&quot;?
+        </div>
+        <Button
+          className="w-full mb-2"
+          onClick={() => {
+            onSelect("text");
+            onClose();
+            setOpen(false);
+          }}
+        >
+          Interpret as text
+        </Button>
+        <Button
+          variant="secondary"
+          className="w-full mb-2"
+          onClick={() => {
+            onSelect("binary");
+            onClose();
+            setOpen(false);
+          }}
+        >
+          Upload as binary
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/prompt-input.tsx
+++ b/src/components/prompt-input.tsx
@@ -9,7 +9,6 @@ import {
 } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { Button } from "ui/button";
-import { notImplementedToast } from "ui/shared-toast";
 import { UseChatHelpers } from "@ai-sdk/react";
 import { SelectModel } from "./select-model";
 import { appStore } from "@/app/store";
@@ -17,12 +16,12 @@ import { useShallow } from "zustand/shallow";
 import { ChatMention, ChatMessageAnnotation, ChatModel } from "app-types/chat";
 import dynamic from "next/dynamic";
 import { ToolModeDropdown } from "./tool-mode-dropdown";
-
 import { ToolSelectDropdown } from "./tool-select-dropdown";
 import { Tooltip, TooltipContent, TooltipTrigger } from "ui/tooltip";
 import { useTranslations } from "next-intl";
 import { Editor } from "@tiptap/react";
 import { WorkflowSummary } from "app-types/workflow";
+import { FileModePicker } from "./file-mode-picker"; // <- reuse from old version
 
 interface PromptInputProps {
   placeholder?: string;
@@ -68,24 +67,27 @@ export default function PromptInput({
       ]),
     );
 
-  const chatModel = useMemo(() => {
-    return model ?? globalModel;
-  }, [model, globalModel]);
-
+  const chatModel = useMemo(() => model ?? globalModel, [model, globalModel]);
   const editorRef = useRef<Editor | null>(null);
 
   const setChatModel = useCallback(
     (model: ChatModel) => {
-      if (setModel) {
-        setModel(model);
-      } else {
-        appStoreMutate({ chatModel: model });
-      }
+      if (setModel) setModel(model);
+      else appStoreMutate({ chatModel: model });
     },
     [setModel, appStoreMutate],
   );
 
   const [toolMentionItems, setToolMentionItems] = useState<ChatMention[]>([]);
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
+
+  type UploadedFile = {
+    file: File;
+    mode: "text" | "binary";
+  };
+  const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const onSelectWorkflow = useCallback((workflow: WorkflowSummary) => {
     const workflowMention: ChatMention = {
@@ -97,7 +99,6 @@ export default function PromptInput({
     };
     editorRef.current
       ?.chain()
-
       .insertContent({
         type: "mention",
         attrs: {
@@ -109,36 +110,49 @@ export default function PromptInput({
       .run();
   }, []);
 
-  const submit = () => {
+  const submit = async () => {
     if (isLoading) return;
     const userMessage = input?.trim() || "";
-    if (userMessage.length === 0) return;
+    if (!userMessage && uploadedFiles.length === 0) return;
+
     const annotations: ChatMessageAnnotation[] = [];
     if (toolMentionItems.length > 0) {
-      annotations.push({
-        mentions: toolMentionItems,
-      });
+      annotations.push({ mentions: toolMentionItems });
     }
-    setToolMentionItems([]);
-    setInput("");
+
+    const fileParts = await Promise.all(
+      uploadedFiles.map(async ({ file, mode }) => {
+        const content = await file.arrayBuffer();
+        return {
+          type: "text" as const,
+          text:
+            mode === "text"
+              ? `File "${file.name}":\n${new TextDecoder().decode(content)}`
+              : `ATTACHMENT (do not interpret): File "${file.name}":\n${Array.from(new Uint8Array(content)).join(",")}`,
+        };
+      }),
+    );
+
     append!({
       role: "user",
       content: "",
       annotations,
       parts: [
-        {
-          type: "text",
-          text: userMessage,
-        },
+        ...fileParts,
+        ...(userMessage ? [{ type: "text", text: userMessage }] : []),
       ],
     });
+
+    setToolMentionItems([]);
+    setInput("");
+    setUploadedFiles([]);
   };
 
   return (
     <div className="max-w-3xl mx-auto fade-in animate-in">
       <div className="z-10 mx-auto w-full max-w-3xl relative">
-        <fieldset className="flex w-full min-w-0 max-w-full flex-col px-2">
-          <div className="rounded-4xl backdrop-blur-sm transition-all duration-200 bg-muted/80 relative flex w-full flex-col cursor-text z-10 border items-stretch focus-within:border-muted-foreground hover:border-muted-foreground p-3">
+        <fieldset className="flex w-full flex-col px-2">
+          <div className="rounded-4xl backdrop-blur-sm bg-muted/80 transition-all duration-200 relative flex flex-col cursor-text border focus-within:border-muted-foreground hover:border-muted-foreground p-3">
             <div className="flex flex-col gap-3.5 px-1">
               <div className="relative min-h-[2rem]">
                 <ChatMentionInput
@@ -150,13 +164,63 @@ export default function PromptInput({
                   ref={editorRef}
                 />
               </div>
-              <div className="flex w-full items-center z-30 gap-1.5">
+
+              {/* uploaded files list */}
+              <div className="flex flex-wrap gap-2">
+                {uploadedFiles.map((uf, index) => (
+                  <div
+                    key={index}
+                    className="flex items-center gap-1 border rounded px-2 py-1 bg-muted"
+                  >
+                    <span className="text-xs truncate">
+                      {uf.file.name} ({uf.mode})
+                    </span>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      onClick={() =>
+                        setUploadedFiles((prev) =>
+                          prev.filter((_, i) => i !== index),
+                        )
+                      }
+                    >
+                      ✕
+                    </Button>
+                  </div>
+                ))}
+              </div>
+
+              <div className="flex items-center gap-1.5 z-30">
+                {/* upload file button */}
                 <div
                   className="cursor-pointer text-muted-foreground hover:ring ring-input rounded-full p-2 bg-transparent hover:bg-muted transition-all duration-200"
-                  onClick={notImplementedToast}
+                  onClick={() => fileInputRef.current?.click()}
                 >
                   <Paperclip className="size-4" />
                 </div>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  hidden
+                  onChange={(e) => {
+                    if (e.target.files?.length) {
+                      setPendingFile(e.target.files[0]);
+                    }
+                  }}
+                />
+                {pendingFile && (
+                  <FileModePicker
+                    file={pendingFile}
+                    onSelect={(mode) => {
+                      setUploadedFiles((prev) => [
+                        ...prev,
+                        { file: pendingFile, mode },
+                      ]);
+                      setPendingFile(null);
+                    }}
+                    onClose={() => setPendingFile(null)}
+                  />
+                )}
 
                 {!toolDisabled && (
                   <>
@@ -168,6 +232,7 @@ export default function PromptInput({
                     />
                   </>
                 )}
+
                 <div className="flex-1" />
 
                 <SelectModel onSelect={setChatModel} defaultModel={chatModel}>
@@ -181,11 +246,12 @@ export default function PromptInput({
                     <ChevronDown className="size-3" />
                   </Button>
                 </SelectModel>
+
                 {!isLoading && !input.length && !voiceDisabled ? (
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <div
-                        onClick={() => {
+                        onClick={() =>
                           appStoreMutate((state) => ({
                             voiceChat: {
                               ...state.voiceChat,
@@ -193,8 +259,8 @@ export default function PromptInput({
                               threadId: currentThreadId ?? undefined,
                               projectId: currentProjectId ?? undefined,
                             },
-                          }));
-                        }}
+                          }))
+                        }
                         className="border fade-in animate-in cursor-pointer text-background rounded-full p-2 bg-primary hover:bg-primary/90 transition-all duration-200"
                       >
                         <AudioWaveformIcon size={16} />
@@ -205,11 +271,8 @@ export default function PromptInput({
                 ) : (
                   <div
                     onClick={() => {
-                      if (isLoading) {
-                        onStop();
-                      } else {
-                        submit();
-                      }
+                      if (isLoading) onStop();
+                      else submit();
                     }}
                     className="fade-in animate-in cursor-pointer text-muted-foreground rounded-full p-2 bg-secondary hover:bg-accent-foreground hover:text-accent transition-all duration-200"
                   >


### PR DESCRIPTION
✏️ Description
This PR adds support for file attachments in the chat interface.
Specifically, it introduces a FileModePicker component that allows users to choose how to upload files:

Interpret the file as text (e.g. source code, logs)

Upload the file as binary (e.g. images, PDFs)

🔍 Details
Added a FileModePicker React component with UI buttons for selecting upload mode.

Implemented filename truncation for long file names.

Used a popover for a lightweight, non-intrusive file mode selection.